### PR TITLE
fix: resolve locales with find locale

### DIFF
--- a/packages/nuxt-i18n/src/nuxt3.ts
+++ b/packages/nuxt-i18n/src/nuxt3.ts
@@ -8,7 +8,7 @@ export async function setupNuxt3(nuxt: Nuxt) {
   // resolve vue-i18n
   const vueI18nPath = nuxt.options.dev
     ? 'vue-i18n/dist/vue-i18n.esm-bundler.js'
-    : 'vue-i18n/dist/vue-i18n-runtime.esm-bundler.js'
+    : 'vue-i18n/dist/vue-i18n.runtime.esm-bundler.js'
   nuxt.options.alias['vue-i18n'] = resolveModule(vueI18nPath, {
     paths: nuxt.options.modulesDir
   })

--- a/packages/nuxt-i18n/src/utils.ts
+++ b/packages/nuxt-i18n/src/utils.ts
@@ -1,6 +1,6 @@
 import { resolveFiles } from '@nuxt/kit'
 import { parse } from 'pathe'
-import { isObject, isString } from '@intlify/shared'
+import { isString } from '@intlify/shared'
 
 import type { LocaleObject } from 'vue-i18n-routing'
 import type { NuxtI18nOptions, LocaleInfo } from './types'
@@ -23,7 +23,7 @@ export async function resolveLocales(path: string, locales: LocaleObject[]): Pro
   return files.map(file => {
     const parsed = parse(file)
     const locale = findLocales(locales, parsed.base)
-    return locales == null
+    return locale === undefined
       ? {
           path: file,
           file: parsed.base,
@@ -33,8 +33,6 @@ export async function resolveLocales(path: string, locales: LocaleObject[]): Pro
   })
 }
 
-function findLocales(locales: NonNullable<NuxtI18nOptions['locales']>, filename: string) {
-  // @ts-ignore
-  const ret = locales.find((locale: string | LocaleObject) => isObject(locale) && locale.file === filename)
-  return ret != null ? (ret as LocaleObject) : null
+function findLocales(locales: LocaleObject[], filename: string) {
+  return locales.find((locale: string | LocaleObject) => locale.file === filename)
 }


### PR DESCRIPTION
As I understand, `findLocales` will always receive the normalized locales. Thus, there's no need to check for if the input is an object.

I guess upstream is an error in:

https://github.com/kazupon/nuxt-i18n/blob/83bf2af964a8f17cb457864ca6934474ce5402e3/packages/nuxt-i18n/src/utils.ts#L26

Should be `locale`, not `locales`, right? Fixed that in the current change.

Feel free to merge or close, just some ideas. 🙂 